### PR TITLE
Make callables nicer to work with

### DIFF
--- a/src/Workers.php
+++ b/src/Workers.php
@@ -1,0 +1,74 @@
+<?php
+
+
+namespace AlwaysBlank\Brief;
+
+
+class Workers
+{
+    protected $workers;
+    protected $current;
+
+    public function __construct()
+    {
+        $this->workers = [];
+    }
+
+    /**
+     * Add a callable to the repository.
+     *
+     * @param string $handle
+     * @param        $callable
+     *
+     * @return $this
+     */
+    public function add(string $handle, $callable)
+    {
+        if (is_callable($callable)) {
+            $this->workers[$handle] = $callable;
+        }
+
+        return $this;
+    }
+
+    /**
+     * See if a handle exists in the repository.
+     *
+     * @param $handle
+     *
+     * @return bool
+     */
+    public function isSet($handle)
+    {
+        return isset($this->workers[$handle]);
+    }
+
+    /**
+     * See if a handle is callable (and exists).
+     *
+     * @param $handle
+     *
+     * @return bool
+     */
+    public function isCallable($handle)
+    {
+        return $this->isSet($handle) && is_callable($this->workers[$handle]);
+    }
+
+    /**
+     * Safely call something; returns null if the handle doesn't exist.
+     *
+     * @param string $handle
+     * @param mixed  ...$arguments
+     *
+     * @return mixed|null
+     */
+    public function call(string $handle, ...$arguments)
+    {
+        if (isset($this->workers[$handle]) && is_callable($this->workers[$handle])) {
+            return $this->workers[$handle](...$arguments);
+        }
+
+        return null;
+    }
+}

--- a/tests/WorkersTest.php
+++ b/tests/WorkersTest.php
@@ -1,0 +1,15 @@
+<?php
+
+
+use AlwaysBlank\Brief\Workers;
+use PHPUnit\Framework\TestCase;
+
+class WorkersTest extends TestCase
+{
+
+    public function testCallingNonexistentWorkerReturnsNull()
+    {
+        $Workers = new Workers();
+        $this->assertNull($Workers->call('does-not-exist'));
+    }
+}


### PR DESCRIPTION
This implements a simple container for callables that requires us to do
way fewer checks and tests when working with them.

It also eliminates the rather weird internal practice of allowing for
`true` as a valid callable over the life of the objects: Now it checks
for that value on instantiation and then creates an anonymous function
to handle that, which simplifies those interactions a great deal.

This closes #9